### PR TITLE
fix: 홈 지출내역에서 이동된 달로 조회되는문제 수정

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,8 +5,6 @@ import dayjs from 'dayjs'
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getMonthlyExpenses, MonthlyExpenses } from 'src/api/MonthlyExpenses'
-import { useRecoilValue } from 'recoil'
-import { dateState } from 'src/recoil/DateState'
 import { SlideMenu } from '@/components/home/SlideMenu'
 import axios from 'axios'
 
@@ -15,7 +13,6 @@ export const Home = () => {
   const token = localStorage.getItem('token')
   let id = localStorage.getItem('id')
 
-  const monthFilter = useRecoilValue<number>(dateState)
   const [monthAmount, setMonthAmount] = useState<MonthlyExpenses[]>([])
 
   const now = dayjs()
@@ -57,7 +54,8 @@ export const Home = () => {
   const getExpenses = async id => {
     try {
       const year: number = Number(thisMonth.slice(0, 4))
-      const res = await getMonthlyExpenses(year, monthFilter, `team9-${id}`)
+      const month: number = Number(thisMonth.slice(5, 7))
+      const res = await getMonthlyExpenses(year, month, `team9-${id}`)
       setMonthAmount(res)
     } catch (error) {
       console.error('Error fetching data:', error)
@@ -137,7 +135,6 @@ export const Home = () => {
     setthisMonthIncome(positiveMonthAmount)
   }
 
-  //업데이트 새로고침 해야됨
   useEffect(() => {
     if (Object.keys(monthAmount).length > 0) {
       getTodayExpense()

--- a/src/pages/LogAccount.tsx
+++ b/src/pages/LogAccount.tsx
@@ -10,8 +10,6 @@ import dayjs, { Dayjs } from 'dayjs'
 import { ArrowLeftIcon } from '@heroicons/react/outline'
 import { logExpense } from '@/api/LogAccount'
 import { getMonthlyExpenses } from 'src/api/MonthlyExpenses'
-import { useRecoilValue } from 'recoil'
-import { dateState } from 'src/recoil/DateState'
 
 export const LogAccount = () => {
   const id = localStorage.getItem('id')
@@ -28,7 +26,6 @@ export const LogAccount = () => {
 
   const navigate = useNavigate()
   const [thisMonth] = useState(now.format('YYYY.MM.DD'))
-  const monthFilter = useRecoilValue<number>(dateState)
 
   const inputNumberFormat = (event: KeyboardEvent<HTMLInputElement>) => {
     setExpense(comma(uncomma(event.currentTarget.value)))
@@ -69,8 +66,8 @@ export const LogAccount = () => {
   const getExpenses = async () => {
     try {
       const year: number = Number(thisMonth.slice(0, 4))
-      const res = await getMonthlyExpenses(year, monthFilter, USERID)
-      console.log(res)
+      const month: number = Number(thisMonth.slice(5, 7))
+      await getMonthlyExpenses(year, month, USERID)
     } catch (error) {
       console.error('Error fetching data:', error)
     }


### PR DESCRIPTION
로그인 후 홈에서 지출내역으로 접근 후 조회하는 달 이동후 다시 홈으로 나오면 
마지막으로 조회한 달로 홈에서 조회되는 문제 수정 
-> 리코일에서 조회하던 달 기존 달로 수정 